### PR TITLE
fix: eslint fixes.

### DIFF
--- a/packages/config-eslint/presets/typescript.js
+++ b/packages/config-eslint/presets/typescript.js
@@ -32,6 +32,7 @@ module.exports = {
         'func-call-spacing': 'off',
         'no-restricted-globals': 'off',
         'no-unused-vars': 'off',
+        'no-unused-expressions': 'off', // Replaced with typescript version
 
         // IMPORT (Conflicts with TS patterns)
         'import/extensions': [
@@ -111,6 +112,7 @@ module.exports = {
         '@typescript-eslint/camelcase': 'warn',
         '@typescript-eslint/consistent-type-definitions': ['error', 'interface'],
         '@typescript-eslint/interface-name-prefix': 'warn',
+        '@typescript-eslint/no-unused-expressions': ['error'],
       },
     },
   ],

--- a/packages/config-eslint/presets/typescript.js
+++ b/packages/config-eslint/presets/typescript.js
@@ -111,7 +111,7 @@ module.exports = {
         '@typescript-eslint/unified-signatures': 'warn',
         '@typescript-eslint/camelcase': 'warn',
         '@typescript-eslint/consistent-type-definitions': ['error', 'interface'],
-        '@typescript-eslint/interface-name-prefix': 'warn',
+        '@typescript-eslint/interface-name-prefix': ['warn', { prefixWithI: 'always' }],
         '@typescript-eslint/no-unused-expressions': ['error'],
       },
     },


### PR DESCRIPTION
- `no-unused-expressions`: replaced with typescript version.
- `interface-name-prefix`: enabled with `I` prefix - warning only.